### PR TITLE
Update logic for computing the closest handle

### DIFF
--- a/es/Range.js
+++ b/es/Range.js
@@ -174,14 +174,16 @@ var Range = function (_React$Component) {
     value: function getClosestBound(value) {
       var bounds = this.state.bounds;
       var overrideIndex = this.props.overrideIndex;
+      var offsetPx = this.calcOffset(value) / 100 * this.getSliderLength();
+      var lowerBoundPx = this.calcOffset(this.getLowerBound()) / 100 * this.getSliderLength();
+      var upperBoundPx = this.calcOffset(this.getUpperBound()) / 100 * this.getSliderLength();
 
       if (overrideIndex) {
-        // Change handles to only be moved if the user clicks within 1% of their value.
-        const handleValue = (this.getUpperBound() - this.getLowerBound()) * 0.01;
-        if (value <= this.getLowerBound() + handleValue) {
+
+        if (offsetPx <= lowerBoundPx + 8) {
           return 0;
         }
-        if (value >= this.getUpperBound() - handleValue) {
+        if (offsetPx >= upperBoundPx - 8) {
           return bounds.length - 1;
         }
         return overrideIndex;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rc-slider",
-  "version": "8.6.14+applied",
+  "version": "8.6.15+applied",
   "description": "Slider UI component for React",
   "keywords": [
     "react",


### PR DESCRIPTION
Update the logic for computing when a handle is clicked. Previously it depended on the size of the interval, but it should be fixed based on pixels (i.e. whenever you click one of the handles).